### PR TITLE
feat: KPI-176 add headers to add investment handler

### DIFF
--- a/src/handlers/investments/add_investment_handler.py
+++ b/src/handlers/investments/add_investment_handler.py
@@ -22,7 +22,7 @@ def handler(event, _):
             raise AppError("No data provided")
 
         company_id = event.get("pathParameters").get("company_id")
-        investment = json.loads(json.dumps(event.get("body")))
+        investment = json.loads(event.get("body"))
         response = investment_service.add_investment(company_id, investment)
 
         return {

--- a/src/handlers/investments/get_company_investments_handler.py
+++ b/src/handlers/investments/get_company_investments_handler.py
@@ -22,7 +22,12 @@ def handler(event, _):
         return {
             "statusCode": 200,
             "body": json.dumps(company, default=str),
-            "headers": {"Content-Type": "application/json"},
+            "headers": {
+                "Content-Type": "application/json",
+                "Access-Control-Allow-Headers": "Content-Type",
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Methods": "OPTIONS,POST,GET",
+            },
         }
 
     except Exception as error:

--- a/src/service/investments/investments_service.py
+++ b/src/service/investments/investments_service.py
@@ -15,6 +15,7 @@ class InvestmentsService:
                 date_format = "YYYY-MM"
                 select_columns = [
                     "company_id",
+                    "id",
                     f"to_char(investment_date, '{date_format}') as investment_date",
                     f"to_char(divestment_date, '{date_format}') as divestment_date",
                     "round",

--- a/src/tests/data/sample_event_add_investment.json
+++ b/src/tests/data/sample_event_add_investment.json
@@ -1,11 +1,4 @@
 {
     "pathParameters": {"company_id": "b1cc8c13-1db3-461c-9855-1bcee7589d73"},
-    "body": {
-      "invest": "2020-09",
-      "round": 1,
-      "structure": "Primary",
-      "ownership": "Majority",
-      "investor_type": "Public",
-      "investor": "Sample investor"
-    }
+    "body": "{\"invest\": \"2020-09\", \"round\": 1, \"structure\": \"Primary\", \"ownership\": \"Majority\", \"investor_type\": \"Public\", \"investor\": \"Sample investor\"}"
 }

--- a/src/tests/handlers/investments/add_investment_handler_test.py
+++ b/src/tests/handlers/investments/add_investment_handler_test.py
@@ -17,16 +17,26 @@ class TestGetCompanyInvestmentHandler(TestCase):
     ):
         id_from_event = self.event.get("pathParameters").get("company_id")
         investment_from_event = self.event.get("body")
+        expected_investment = {
+            "invest": "2020-09",
+            "round": 1,
+            "structure": "Primary",
+            "ownership": "Majority",
+            "investor_type": "Public",
+            "investor": "Sample investor",
+        }
         mock_add_investment.return_value = self.response
 
         response = handler(self.event, {})
 
-        mock_add_investment.assert_called_with(id_from_event, investment_from_event)
+        mock_add_investment.assert_called_with(
+            id_from_event, json.loads(investment_from_event)
+        )
         mock_create_db_engine.assert_not_called()
         mock_create_db_session.assert_not_called()
         self.assertEqual(response.get("statusCode"), 201)
         self.assertTrue(self.response.get("added"))
-        self.assertEqual(self.response.get("investment"), investment_from_event)
+        self.assertEqual(self.response.get("investment"), expected_investment)
 
     @mock.patch("investments_service.InvestmentsService.add_investment")
     def test_add_investment_fail_no_body_400_response(self, mock_add_investment):


### PR DESCRIPTION
<!--- As a title use the format: [CODE] Jira Issue Title -->

## Jira Link
<!--- Jira link for an issue -->
[Go to Jira](https://kpinetwork.atlassian.net/browse/KPI-XXX)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Hotfix (Bug detected)
- [x] Feature (Issue from an Active Sprint)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Unit Test.
- [x] Coverage.

<!--- Only apply if you need explain details about your pull request -->
## Solution
In this PR, the headers were added to the `get_investments_handler`, the id column was also added to the `get_investments` query, and the `json.dumps` from the `add_investment_handler` was removed.
