### PR TITLE
feat: KPI-283 add tag filter condition in query builder for by year report

### DIFF
--- a/src/handlers/by_metric_report/get_by_metric_report_handler.py
+++ b/src/handlers/by_metric_report/get_by_metric_report_handler.py
@@ -50,6 +50,7 @@ def handler(event, _):
 
         if event.get("queryStringParameters"):
             params = event.get("queryStringParameters")
+            params.pop("tag", None)
             conditions = get_condition_params(params)
             from_main = params.get("from_main", from_main)
             metric = params.get("metric", metric)

--- a/src/handlers/dynamic_report/get_dynamic_report_handler.py
+++ b/src/handlers/dynamic_report/get_dynamic_report_handler.py
@@ -84,6 +84,7 @@ def handler(event, _):
 
         if event.get("queryStringParameters"):
             params = event.get("queryStringParameters")
+            params.pop("tag", None)
             conditions = get_condition_params(params)
             from_main = params.get("from_main", from_main)
             metrics = get_list_param(params.get("metrics"))

--- a/src/handlers/investment_date_report/get_investment_date_report_handler.py
+++ b/src/handlers/investment_date_report/get_investment_date_report_handler.py
@@ -70,6 +70,7 @@ def handler(event, _):
         metrics = []
         if event.get("queryStringParameters"):
             params = event.get("queryStringParameters")
+            params.pop("tag", None)
             conditions = get_condition_params(params)
             company_id = event.get("queryStringParameters").get("company_id")
             from_main = params.get("from_main", from_main)

--- a/src/handlers/universe_overview/get_universe_overview_handler.py
+++ b/src/handlers/universe_overview/get_universe_overview_handler.py
@@ -35,6 +35,7 @@ def handler(event, _):
         conditions = dict()
         if event.get("queryStringParameters"):
             params = event.get("queryStringParameters")
+            params.pop("tag", None)
             conditions = get_condition_params(params)
             year = int(params.get("year", year))
 

--- a/src/service/by_metric_report/metric_report_repository.py
+++ b/src/service/by_metric_report/metric_report_repository.py
@@ -17,7 +17,7 @@ class MetricReportRepository:
                 values = [
                     f"'{element}'" for element in v if element and element.strip()
                 ]
-                filters[f"{TableNames.COMPANY}.{k}"] = values
+                filters[k] = values
         return filters
 
     def get_years(self) -> list:

--- a/src/service/by_year_report/by_year_report_service.py
+++ b/src/service/by_year_report/by_year_report_service.py
@@ -47,7 +47,7 @@ class ByYearReportService:
         return rule_of_40
 
     def get_report_base_data(self, year: str, **conditions) -> dict:
-        filters = self.repository.add_company_filters(**conditions)
+        filters = self.repository.add_filters(**conditions)
         data = self.repository.get_actuals_values(year, filters)
         budget_records = self.repository.get_budget_values(
             year, [year], filters, metrics=[MetricNames.REVENUE, MetricNames.EBITDA]

--- a/src/service/dynamic_report/dynamic_report.py
+++ b/src/service/dynamic_report/dynamic_report.py
@@ -26,7 +26,7 @@ class DynamicReport:
         company_id: str = None,
         **conditions,
     ) -> dict:
-        filters = self.by_year_repository.add_company_filters(**conditions)
+        filters = self.by_year_repository.add_filters(**conditions)
 
         data = self.by_year_repository.get_actuals_values(year, filters)
         budget_values = self.by_year_repository.get_budget_values(year, [year], filters)

--- a/src/service/universe_overview/universe_overview_service.py
+++ b/src/service/universe_overview/universe_overview_service.py
@@ -19,7 +19,7 @@ class UniverseOverviewService:
         self.repository = repository
 
     def get_metrics_by_year(self, year: str, **conditions) -> dict:
-        filters = self.repository.add_company_filters(**conditions)
+        filters = self.repository.add_filters(**conditions)
         metrics = [MetricNames.REVENUE, MetricNames.EBITDA]
         data = self.repository.get_actuals_values(year, filters, metrics)
         budget_values = self.repository.get_budget_values(

--- a/src/tests/handlers/scenario/delete_scenarios_handler_test.py
+++ b/src/tests/handlers/scenario/delete_scenarios_handler_test.py
@@ -1,4 +1,3 @@
-# test delete scenarios handler test
 import json
 from src.tests.data.data_reader import read
 from unittest import TestCase, mock

--- a/src/tests/service/base_metrics/base_metrics_repository_test.py
+++ b/src/tests/service/base_metrics/base_metrics_repository_test.py
@@ -39,10 +39,17 @@ class TestBaseMetricsRepository(TestCase):
         attrs = {"process_query_list_results.return_value": response}
         self.mock_response_sql.configure_mock(**attrs)
 
-    def test_add_company_filters_with_data(self):
-        expected_out = {"company.sector": ["'Application'"]}
+    def test_add_company_filters_with_data_should_return_dict_with_sql_valid_values(
+        self,
+    ):
+        condition_name, condition_value = (
+            "company.inves_profile_name",
+            "Family office",
+        )
+        expected_out = {condition_name: [f"'{condition_value}'"]}
+        conditions = {condition_name: [condition_value]}
 
-        filters_out = self.repository.add_company_filters(sector=["Application"])
+        filters_out = self.repository.add_filters(**conditions)
 
         self.assertEqual(filters_out, expected_out)
 

--- a/src/tests/service/by_metric_report/metric_report_repository_test.py
+++ b/src/tests/service/by_metric_report/metric_report_repository_test.py
@@ -25,14 +25,21 @@ class TestMetricReportRepository(TestCase):
         attrs = {"process_query_list_results.return_value": response}
         self.mock_response_sql.configure_mock(**attrs)
 
-    def test_add_company_filters_with_data(self):
-        expected_out = {"company.sector": ["'Application'"]}
+    def test_add_company_filters_with_data_should_return_dict_with_valid_sql_values(
+        self,
+    ):
+        condition_name, condition_value = (
+            "company.inves_profile_name",
+            "Family office",
+        )
+        expected_out = {condition_name: [f"'{condition_value}'"]}
+        conditions = {condition_name: [condition_value]}
 
-        filters_out = self.repository.add_company_filters(sector=["Application"])
+        filters_out = self.repository.add_company_filters(**conditions)
 
         self.assertEqual(filters_out, expected_out)
 
-    def test_get_years_success(self):
+    def test_get_years_should_return_valid_year_dict_list_when_successful_db_call(self):
         expected_years = [2020, 2021, 2022]
         self.mock_response_list_query_sql(
             [{"year": 2020}, {"year": 2021}, {"year": 2022}]
@@ -42,56 +49,62 @@ class TestMetricReportRepository(TestCase):
 
         self.assertEqual(years, expected_years)
 
-    def test_get_years_fail(self):
+    def test_get_years_should_return_empty_list_when_db_call_fails(self):
         self.mock_session.execute.side_effect = Exception("error")
 
         years = self.repository.get_years()
 
         self.assertEqual(years, [])
 
-    def test_get_base_metric_success(self):
+    def test_get_base_metric_should_return_base_metrics_list_when_successful_call(self):
         self.mock_response_list_query_sql(self.records)
 
         metrics = self.repository.get_base_metric("Revenue", "Actuals", dict())
 
         self.assertEqual(metrics, self.records)
 
-    def test_get_base_metric_fail(self):
+    def test_get_base_metric_should_return_empty_list_when_call_fails(self):
         self.mock_session.execute.side_effect = Exception("error")
 
         metrics = self.repository.get_base_metric("Revenue", "Actuals", dict())
 
         self.assertEqual(metrics, [])
 
-    def test_get_actuals_vs_budget_metric_success(self):
+    def test_get_actuals_vs_budget_should_return_metric_dict_list_when_successful_call(
+        self,
+    ):
         self.mock_response_list_query_sql(self.records)
 
         metrics = self.repository.get_actuals_vs_budget_metric("Ebitda", dict())
 
         self.assertEqual(metrics, self.records)
 
-    def test_get_actuals_vs_budget_metric_fail(self):
+    def test_get_actuals_vs_budget_metric_should_return_empty_list_when_exception_raised(
+        self,
+    ):
         self.mock_session.execute.side_effect = Exception("error")
 
         metrics = self.repository.get_actuals_vs_budget_metric("Ebitda", dict())
 
         self.assertEqual(metrics, [])
 
-    def test_get_ebitda_margin_success(self):
+    def test_get_ebitda_margin_should_return_metric_dict_list_when_successful_call(
+        self,
+    ):
         self.mock_response_list_query_sql(self.records)
 
         metrics = self.repository.get_ebitda_margin_metric(dict())
 
         self.assertEqual(metrics, self.records)
 
-    def test_get_ebitda_margin_fail(self):
+    def test_get_ebitda_margin_should_return_empty_list_when_exception_raised(self):
         self.mock_session.execute.side_effect = Exception("error")
 
         metrics = self.repository.get_ebitda_margin_metric(dict())
 
         self.assertEqual(metrics, [])
 
-    def test_get_most_recent_revenue_success(self):
+    def test_get_most_recent_revenue_should_return_dict_list_when_successful_call(self):
         expected_metrics = [
             {"id": "1", "name": "Actuals-2021", "value": 30},
             {"id": "1", "name": "Actuals-2020", "value": 20},
@@ -102,7 +115,9 @@ class TestMetricReportRepository(TestCase):
 
         self.assertEqual(metrics, expected_metrics)
 
-    def test_get_most_recent_revenue_fail(self):
+    def test_get_most_recent_revenue_should_return_empty_list_when_exception_raised(
+        self,
+    ):
         self.mock_session.execute.side_effect = Exception("error")
 
         metrics = self.repository.get_most_recents_revenue(dict())
@@ -120,7 +135,9 @@ class TestMetricReportRepository(TestCase):
             ],
         ]
     )
-    def test_get_arguments(self, metric, scenario, expected_arguments):
+    def test_get_arguments_should_return_dynamic_args_with_different_input(
+        self, metric, scenario, expected_arguments
+    ):
 
         arguments = self.repository._MetricReportRepository__get_arguments(
             {}, metric, scenario

--- a/src/tests/utils/commons_functions_test.py
+++ b/src/tests/utils/commons_functions_test.py
@@ -5,6 +5,7 @@ from src.utils.commons_functions import (
     get_condition_params,
     get_edit_modify_condition_params,
 )
+from src.utils.app_names import TableNames
 
 
 class TestQueryBuilder(TestCase):
@@ -15,48 +16,57 @@ class TestQueryBuilder(TestCase):
             "sector": "Application Software,Computer",
             "vertical": "Law,Insurance",
             "size": "<$10million,$30-50million",
+            "name": "Company A,Company B",
+            "tag": "Industry",
         }
 
-    def test_remove_white_spaces(self):
+    def test_remove_white_spaces_should_remove_empty_spaces(self):
         result = remove_white_spaces(self.text)
 
         expected_result = "Test"
 
         self.assertEqual(result, expected_result)
 
-    def test_get_list_param_with_no_empty_string(self):
+    def test_get_list_param_should_return_same_values_in_a_list_with_no_empty_string(
+        self,
+    ):
         values = "1,2,3,4"
 
         out = get_list_param(values)
 
         self.assertEqual(out, self.expected_full_list)
 
-    def test_get_list_param_with_empty_string(self):
+    def test_get_list_param_should_return_empty_list_with_empty_string(self):
         values = ""
 
         out = get_list_param(values)
 
         self.assertEqual(out, [])
 
-    def test_get_condition_params(self):
+    def test_get_condition_params_should_return_valid_dict_conditions_with_no_empty_param_dict(
+        self,
+    ):
         expected_result = {
-            "sector": self.params["sector"].split(","),
-            "vertical": self.params["vertical"].split(","),
             "size_cohort": self.params["size"].split(","),
+            f"{TableNames.TAG}.name": self.params["tag"].split(","),
         }
 
         conditions = get_condition_params(self.params)
 
         self.assertEqual(conditions, expected_result)
 
-    def test_get_condition_params_with_empty_dict(self):
+    def test_get_condition_params_should_return_empty_condition_dict_with_empty_dict_input(
+        self,
+    ):
         expected_result = dict()
 
         conditions = get_condition_params(dict())
 
         self.assertEqual(conditions, expected_result)
 
-    def test_get_edit_modify_conditions_without_empty_strings(self):
+    def test_get_edit_modify_conditions_should_return_full_condition_dict_without_empty_strings(
+        self,
+    ):
         edit_params = {"names": "Company A", "sectors": "Application Software"}
         expected_conditions = {
             "name": [edit_params["names"]],

--- a/src/utils/app_names.py
+++ b/src/utils/app_names.py
@@ -13,6 +13,8 @@ class TableNames(StrEnum):
     CURRENCY_METRIC = "currency_metric"
     METRIC_TYPES = "metric_types"
     METRIC_SORT = "metric_sort"
+    TAG = "tag"
+    COMPANY_TAG = "company_tag"
 
 
 class ScenarioNames(StrEnum):

--- a/src/utils/commons_functions.py
+++ b/src/utils/commons_functions.py
@@ -1,3 +1,6 @@
+from app_names import TableNames
+
+
 def remove_white_spaces(string: str):
     from re import sub
 
@@ -24,11 +27,10 @@ def get_conditions(query_params: dict, attributes: dict) -> dict:
 
 def get_company_attr() -> dict:
     return {
-        "sector": "sector",
-        "vertical": "vertical",
-        "investor_profile": "inves_profile_name",
+        "investor_profile": f"{TableNames.COMPANY}.inves_profile_name",
         "growth_profile": "margin_group",
         "size": "size_cohort",
+        "tag": f"{TableNames.TAG}.name",
     }
 
 


### PR DESCRIPTION
<!--- As a title use the format: [CODE] Jira Issue Title -->

## Jira Link
<!--- Jira link for an issue -->
[Go to Jira](https://kpinetwork.atlassian.net/browse/KPI-283)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Hotfix (Bug detected)
- [x] Feature (Issue from an Active Sprint)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Unit Test.
- [ ] Coverage.

<!--- Only apply if you need to explain details about your pull request -->
## Solution
Tag filter condition and tag tables join were added in the base metric repository class, as the change for the filter was done in the function to get condition filter for query string parameters a line was added in other reports to avoid having the tag condition and break the current functionality.
There are other tickets for dynamic, by metric, and investment date reports.