### PR TITLE
fix: KPI-272 fix path parameter in get tags by company

### DIFF
--- a/src/handlers/tags/get_tags_by_company_handler.py
+++ b/src/handlers/tags/get_tags_by_company_handler.py
@@ -33,10 +33,10 @@ def handler(event, _):
         if not access:
             raise AppError("No permissions to load tags")
 
-        if not event.get("pathParameters").get("company_id", None):
+        if not event.get("pathParameters").get("id", None):
             raise AppError("No data provided")
 
-        company_id = event.get("pathParameters").get("company_id")
+        company_id = event.get("pathParameters").get("id")
         tags = tags_service.get_tags_by_company(company_id)
 
         return {

--- a/src/tests/data/sample_event_tags.json
+++ b/src/tests/data/sample_event_tags.json
@@ -9,7 +9,7 @@
         }
     },
     "pathParameters": {
-        "company_id": "yec4b0212-m385-4828-814p-0e6b21d98f87"
+        "id": "yec4b0212-m385-4828-814p-0e6b21d98f87"
     },
     "body": 
         "{\"name\": \"Sample tag\", \"companies\": [\"id1\", \"id2\"]}"


### PR DESCRIPTION
<!--- As a title use the format: [CODE] Jira Issue Title -->

## Jira Link
<!--- Jira link for an issue -->
[Go to Jira](https://kpinetwork.atlassian.net/browse/KPI-XXX)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Hotfix (Bug detected)
- [ ] Feature (Issue from an Active Sprint)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Unit Test.
- [ ] Coverage.

<!--- Only apply if you need explain details about your pull request -->
## Solution
The event is returning the path parameter as `id` and in the code we were obtaining it as `company_id` so the endpoint returned a `400 error`, the solution was to change `company_id` to `id`