### PR TITLE
fix: KPI-289 fix filters in dynamic report

### DIFF
--- a/src/service/dynamic_report/dynamic_report.py
+++ b/src/service/dynamic_report/dynamic_report.py
@@ -43,7 +43,7 @@ class DynamicReport:
 
     def remove_fields(self, company_data: dict, headers: list) -> None:
         company_data.pop("prior_actuals_revenue", None)
-        header = ["id"]
+        header = ["id", "size_cohort", "margin_group"]
         header.extend(headers)
         to_delete = set(company_data.keys()).difference(header)
         for field in to_delete:

--- a/src/tests/service/dynamic_report/dynamic_report_test.py
+++ b/src/tests/service/dynamic_report/dynamic_report_test.py
@@ -216,7 +216,9 @@ class TestDynamicReport(TestCase):
 
         mock_anonymize_company.assert_called()
 
-    def test_add_metrics(self):
+    def test_add_metrics_should_overwrite_data_dict_with_metrics_when_is_successful(
+        self,
+    ):
         metrics = ["gross_profit", "id", "name"]
         data = {
             "1": {
@@ -226,10 +228,19 @@ class TestDynamicReport(TestCase):
                 "prior_actuals_revenue": 34,
             }
         }
+        expected_data = {
+            "1": {
+                "name": "Test Company",
+                "gross_profit": "NA",
+                "margin_group": "$30-<50 million",
+                "size_cohort": "$30-<50 million",
+            }
+        }
+        self.mock_profile_range.get_range_from_value.return_value = self.range["label"]
 
         self.report_instance.add_metrics(data, metrics, self.profile_ranges)
 
-        self.assertEqual(data, {"1": {"name": "Test Company", "gross_profit": "NA"}})
+        self.assertEqual(data, expected_data)
 
     @patch("src.service.dynamic_report.dynamic_report.DynamicReport.add_metrics")
     @patch("src.service.dynamic_report.dynamic_report.DynamicReport.anonymize_data")


### PR DESCRIPTION
<!--- As a title use the format: [CODE] Jira Issue Title -->

## Jira Link
<!--- Jira link for an issue -->
[Go to Jira](https://kpinetwork.atlassian.net/browse/KPI-XXX)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Hotfix (Bug detected)
- [ ] Feature (Issue from an Active Sprint)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Unit Test.
- [x] Coverage.

<!--- Only apply if you need explain details about your pull request -->
## Solution
When filtering by conditions in `base_metrics_report` using the `filter_by_condition` method, the company to be filtered did not have the `margin_group` or `size_cohort` keys, so a `keyError` was raised. The company arrived without these keys because in the `dynamic_report` the keys that are not necessary to return are removed, using the `remove_fields` method. To avoid that the keys of the filters are eliminated, they were added as headers.